### PR TITLE
Organize MVP plan with team roles

### DIFF
--- a/MVP_PLAN.md
+++ b/MVP_PLAN.md
@@ -1,0 +1,66 @@
+# Finance Manager Dashboard MVP Plan
+
+## Overview
+The Finance Manager Dashboard will provide an intuitive web platform for tracking expenses, managing budgets, and analyzing financial trends while leveraging role-based authentication and AI-driven insights.
+
+## MVP Features
+- User registration and login with secure authentication.
+- Expense tracking with CRUD operations and categorization.
+- Budget creation and monitoring.
+- Financial goal management.
+- Dashboard with interactive charts and summaries.
+- Basic AI chatbot for personalized financial recommendations.
+- User settings including dark mode and account deletion.
+- PostgreSQL for secure and efficient data storage.
+
+## Step-by-Step Implementation
+1. **Project Setup**
+   - Initialize repository with backend (e.g., Node/Express) and frontend (e.g., React).
+   - Configure PostgreSQL database and ORM.
+   - Establish environment configuration and build tooling.
+2. **Authentication**
+   - Implement user registration, login, and session management.
+   - Add role-based access control and optional 2FA.
+3. **Expense Management**
+   - Build REST endpoints for adding, editing, viewing, and deleting expenses.
+   - Create frontend forms and tables for expense input and review.
+   - Automate categorization of expenses where possible.
+4. **Budget & Goals**
+   - Enable users to set budgets and savings goals.
+   - Track progress and flag overspending.
+5. **Dashboard & Analytics**
+   - Display summaries such as income vs. expenses and spending by category.
+   - Include interactive graphs and real-time updates.
+6. **AI Chatbot Integration**
+   - Connect to an AI service to provide financial tips based on user data.
+   - Support simple natural language queries.
+7. **Settings & UX Enhancements**
+   - Implement dark mode toggle and profile settings.
+   - Support account deletion and report sharing.
+8. **Security & Compliance**
+   - Encrypt sensitive data and sanitize inputs to prevent injection attacks.
+   - Maintain audit logs and error handling.
+9. **Testing & Deployment**
+   - Add unit and integration tests.
+   - Deploy MVP to a cloud platform and gather user feedback for iteration.
+
+## Team Roles and Responsibilities
+
+### Backend Developer
+- Establish project scaffolding, configure PostgreSQL, and manage environment settings.
+- Build authentication, authorization, and core REST APIs for expenses, budgets, and goals.
+- Ensure security best practices, data validation, and logging.
+
+### Frontend Developer
+- Implement responsive UI components for login, dashboards, expense tracking, and settings.
+- Integrate charts and interactive visuals for analytics.
+- Handle client-side state management, theming, and accessibility.
+
+### AI & Analytics Developer
+- Integrate the AI chatbot service and develop analytics pipelines.
+- Design data models for insights and support natural language queries.
+- Oversee test automation, deployment pipelines, and performance monitoring.
+
+### Collaboration
+- Conduct regular sync meetings and maintain shared documentation.
+- Use issue tracking to coordinate tasks and code reviews across roles.


### PR DESCRIPTION
## Summary
- Expand MVP planning document with role-based responsibilities for backend, frontend, and AI/analytics developers

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f0591350832dbfb2b1d4fc5eee23