### PR TITLE
Add dashboard and routes for core finance pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,9 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Login from './pages/Login.jsx';
 import Register from './pages/Register.jsx';
 import Home from './pages/Home.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import Transactions from './pages/Transactions.jsx';
+import Budgets from './pages/Budgets.jsx';
 import Layout from './components/Layout.jsx';
 
 function App() {
@@ -11,6 +14,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route path="transactions" element={<Transactions />} />
+          <Route path="budgets" element={<Budgets />} />
           <Route path="login" element={<Login />} />
           <Route path="register" element={<Register />} />
         </Route>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -14,6 +14,7 @@ function Layout() {
         <nav>
           <ul className="nav-links">
             <li><Link to="/">Home</Link></li>
+            <li><Link to="/dashboard">Dashboard</Link></li>
             <li><Link to="/login">Login</Link></li>
             <li><Link to="/register">Register</Link></li>
           </ul>
@@ -28,7 +29,7 @@ function Layout() {
       <div className="content-wrapper">
         <aside className="sidebar">
           <ul>
-            <li><Link to="/">Dashboard</Link></li>
+            <li><Link to="/dashboard">Dashboard</Link></li>
             <li><Link to="/transactions">Transactions</Link></li>
             <li><Link to="/budgets">Budgets</Link></li>
           </ul>

--- a/frontend/src/pages/Budgets.jsx
+++ b/frontend/src/pages/Budgets.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Budgets() {
+  return (
+    <div>
+      <h2>Budgets</h2>
+      <p>Budget planning coming soon.</p>
+    </div>
+  );
+}
+
+export default Budgets;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+function Dashboard() {
+  const balance = 5230.75;
+  const recentTransactions = [
+    { id: 1, date: '2025-05-01', description: 'Grocery Store', amount: -54.23 },
+    { id: 2, date: '2025-05-03', description: 'Salary', amount: 1500.0 },
+    { id: 3, date: '2025-05-05', description: 'Electric Bill', amount: -120.5 },
+  ];
+  const budget = { total: 2000, spent: 950 };
+
+  return (
+    <div className="dashboard">
+      <section className="dashboard-summary">
+        <h2>Current Balance</h2>
+        <p>${balance.toFixed(2)}</p>
+      </section>
+
+      <section className="dashboard-transactions">
+        <h3>Recent Transactions</h3>
+        <ul>
+          {recentTransactions.map((tx) => (
+            <li key={tx.id}>
+              <span>{tx.date} - {tx.description}</span>
+              <span>{tx.amount < 0 ? '-' : ''}${Math.abs(tx.amount).toFixed(2)}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="dashboard-budget">
+        <h3>Budget Summary</h3>
+        <p>Total Budget: ${budget.total.toFixed(2)}</p>
+        <p>Spent: ${budget.spent.toFixed(2)}</p>
+        <p>Remaining: ${(budget.total - budget.spent).toFixed(2)}</p>
+      </section>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Transactions() {
+  return (
+    <div>
+      <h2>Transactions</h2>
+      <p>Transaction management coming soon.</p>
+    </div>
+  );
+}
+
+export default Transactions;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -253,3 +253,38 @@ form div {
   margin-top: 0.25rem;
   font-size: 0.875rem;
 }
+
+/* Dashboard styles */
+.dashboard {
+  display: grid;
+  gap: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.dashboard-summary,
+.dashboard-transactions,
+.dashboard-budget {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.dashboard-transactions ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dashboard-transactions li {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+body.dark-mode .dashboard-summary,
+body.dark-mode .dashboard-transactions,
+body.dark-mode .dashboard-budget {
+  background: #1e293b;
+}


### PR DESCRIPTION
## Summary
- Add Dashboard page with sample metrics for balance, recent transactions, and budget summary
- Configure routes for /dashboard, /transactions, and /budgets with placeholder pages
- Update navigation and styles to support new dashboard and future pages

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c44b8dd5fc832d8c5c7e93af5fc283