### PR TITLE
feat: add sample charts to dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,9 @@
       "name": "finance-dashboard-frontend",
       "version": "0.0.1",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.8.2",
         "react-toastify": "^11.0.5",
@@ -742,6 +744,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1170,6 +1178,18 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1427,6 +1447,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "test": "echo \"No frontend tests yet\" && exit 0"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.8.2",
     "react-toastify": "^11.0.5",

--- a/frontend/src/components/BudgetDistributionChart.jsx
+++ b/frontend/src/components/BudgetDistributionChart.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Pie } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+// Sample budget distribution; replace with backend data when available
+const sampleData = {
+  labels: ['Rent', 'Groceries', 'Utilities', 'Entertainment'],
+  datasets: [
+    {
+      label: 'Budget Allocation',
+      data: [1000, 300, 150, 200],
+      backgroundColor: [
+        'rgba(255, 99, 132, 0.5)',
+        'rgba(54, 162, 235, 0.5)',
+        'rgba(255, 206, 86, 0.5)',
+        'rgba(75, 192, 192, 0.5)',
+      ],
+      borderWidth: 1,
+    },
+  ],
+};
+
+function BudgetDistributionChart({ data = sampleData }) {
+  // TODO: Fetch real budget distribution from backend once available
+  return <Pie data={data} />;
+}
+
+export default BudgetDistributionChart;

--- a/frontend/src/components/SpendingTrendsChart.jsx
+++ b/frontend/src/components/SpendingTrendsChart.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+// Sample monthly spending data; replace with backend data when available
+const sampleData = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+  datasets: [
+    {
+      label: 'Spending ($)',
+      data: [500, 700, 400, 650, 800],
+      backgroundColor: 'rgba(75, 192, 192, 0.5)',
+    },
+  ],
+};
+
+function SpendingTrendsChart({ data = sampleData }) {
+  // TODO: Fetch real spending data from backend once available
+  return <Bar data={data} />;
+}
+
+export default SpendingTrendsChart;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import SpendingTrendsChart from '../components/SpendingTrendsChart.jsx';
+import BudgetDistributionChart from '../components/BudgetDistributionChart.jsx';
 
 function Dashboard() {
   const balance = 5230.75;
@@ -33,6 +35,14 @@ function Dashboard() {
         <p>Total Budget: ${budget.total.toFixed(2)}</p>
         <p>Spent: ${budget.spent.toFixed(2)}</p>
         <p>Remaining: ${(budget.total - budget.spent).toFixed(2)}</p>
+      </section>
+
+      <section className="dashboard-analytics">
+        <h3>Spending Trends</h3>
+        <SpendingTrendsChart />
+
+        <h3>Budget Distribution</h3>
+        <BudgetDistributionChart />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Chart.js and react-chartjs-2 for data visualization
- show sample spending trends and budget distribution charts on dashboard
- placeholder components ready to hook to backend data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4ec887760832db4232264def7082d